### PR TITLE
Add 'all' permission

### DIFF
--- a/services/tabler-world-api/src/graphql/auth/isAdmin.ts
+++ b/services/tabler-world-api/src/graphql/auth/isAdmin.ts
@@ -1,5 +1,5 @@
 import { IPrincipal } from '../types/IPrincipal';
 
 export function isAdmin(principal: IPrincipal) {
-    return principal != null && principal.id === 104301;
+    return principal != null && principal.id === 10430;
 }

--- a/services/tabler-world-api/src/graphql/privacy/DBLevels.ts
+++ b/services/tabler-world-api/src/graphql/privacy/DBLevels.ts
@@ -1,5 +1,5 @@
-export const PUBLIC = '__public__';
-
+export const PUBLIC = 'public';
 export const ASSOCIATION = 'association';
 export const CLUB = 'club';
 export const PRIVATE = 'private';
+export const ALL = 'all';

--- a/services/tabler-world-api/src/graphql/privacy/hasAccess.spec.ts
+++ b/services/tabler-world-api/src/graphql/privacy/hasAccess.spec.ts
@@ -1,4 +1,4 @@
-import { ASSOCIATION, CLUB, PRIVATE, PUBLIC } from './DBLevels';
+import { ALL, ASSOCIATION, CLUB, PRIVATE, PUBLIC } from './DBLevels';
 import { FilterLevel } from './FilterLevel';
 import { hasAccess } from './hasAccess';
 
@@ -6,6 +6,13 @@ import { hasAccess } from './hasAccess';
 // tslint:disable: mocha-no-side-effect-code
 
 describe('hasAccess', () => {
+    test('ALL', () => {
+        expect(hasAccess(ALL, FilterLevel.Public)).toEqual(true);
+        expect(hasAccess(ALL, FilterLevel.SameArea)).toEqual(true);
+        expect(hasAccess(ALL, FilterLevel.SameAssociation)).toEqual(true);
+        expect(hasAccess(ALL, FilterLevel.SameClub)).toEqual(true);
+        expect(hasAccess(ALL, FilterLevel.SamePerson)).toEqual(true);
+    });
 
     test('PUBLIC', () => {
         expect(hasAccess(PUBLIC, FilterLevel.Public)).toEqual(true);

--- a/services/tabler-world-api/src/graphql/privacy/hasAccess.ts
+++ b/services/tabler-world-api/src/graphql/privacy/hasAccess.ts
@@ -1,14 +1,20 @@
-import { ASSOCIATION, CLUB, PRIVATE, PUBLIC } from './DBLevels';
+import { ALL, ASSOCIATION, CLUB, PRIVATE, PUBLIC } from './DBLevels';
 import { FilterLevel } from './FilterLevel';
 
 // error in rule
 // tslint:disable: ter-indent
 
 export function hasAccess(priv: string, level: FilterLevel) {
+    if (priv === ALL) {
+        return true;
+    }
+
+    // same family only, we currently cannot check that
     if (priv === PUBLIC) {
         return true;
     }
 
+    // same person only
     if (priv === PRIVATE) {
         switch (level) {
             case FilterLevel.SamePerson:
@@ -19,6 +25,7 @@ export function hasAccess(priv: string, level: FilterLevel) {
         }
     }
 
+    // same club only
     if (priv === CLUB) {
         switch (level) {
             case FilterLevel.SamePerson:
@@ -30,6 +37,7 @@ export function hasAccess(priv: string, level: FilterLevel) {
         }
     }
 
+    // same assocation only
     if (priv === ASSOCIATION) {
         switch (level) {
             case FilterLevel.SamePerson:

--- a/services/tabler-world-api/src/sql/04 privacy.pgsql
+++ b/services/tabler-world-api/src/sql/04 privacy.pgsql
@@ -6,6 +6,7 @@ DROP FUNCTION if EXISTS get_privacylevel cascade;
 CREATE OR REPLACE FUNCTION get_privacylevel(privacy jsonb, field text)
   RETURNS text AS
 $func$
+    -- share with all associations (public) is the default
     select COALESCE((
         select value->>'level'
         from jsonb_array_elements(privacy) t
@@ -47,6 +48,12 @@ BEGIN
         return false;
     end if;
 
+    -- all families
+    if level = 'all' then
+        return true;
+    end if;
+
+    -- same famnily, we currently cannot check that
     if level = 'public' then
         return true;
     end if;


### PR DESCRIPTION
Allow new 'all' permission to access data for associated organizations: LCD, OTD, ...