### PR TITLE
RedisLocation might return stale members

### DIFF
--- a/packages/tabler-world-cache/src/redis/MultiCommand.ts
+++ b/packages/tabler-world-cache/src/redis/MultiCommand.ts
@@ -104,6 +104,14 @@ export class MultiCommand {
         return this;
     }
 
+    public zrem(set: string, ...member: string[]) {
+        this.logger.debug('multi:zrem', set, member);
+        this.cmds += 1;
+
+        this.pipeline = this.pipeline.zrem(set, ...member);
+        return this;
+    }
+
     public geoadd(key: string, longitude: number, latitude: number, member: string) {
         this.logger.debug('multi:geoadd', key, longitude, latitude, member);
         this.cmds += 1;
@@ -121,11 +129,11 @@ export class MultiCommand {
         return this;
     }
 
-    public del(key: string) {
+    public del(...key: string[]) {
         this.logger.debug('multi:del', key);
         this.cmds += 1;
 
-        this.pipeline = this.pipeline.del(key);
+        this.pipeline = this.pipeline.del(...key);
         return this;
     }
 

--- a/services/tabler-world-api/src/graphql/location/RedisLocationStorage.ts
+++ b/services/tabler-world-api/src/graphql/location/RedisLocationStorage.ts
@@ -1,11 +1,21 @@
 import { IORedisClient } from '@mskg/tabler-world-cache';
 import { StopWatch } from '@mskg/tabler-world-common';
 import { DataSourceConfig } from 'apollo-datasource';
-import { chunk, filter, keys, take, values } from 'lodash';
+import { chunk, keys, slice, take, values } from 'lodash';
 import { createIORedisClient } from '../helper/createIORedisClient';
 import { Metrics } from '../logging/Metrics';
 import { IApolloContext } from '../types/IApolloContext';
 import { ILocationStorage, Location, PutLocation, QueryResult, QueryResultRecord } from './ILocationStorage';
+
+type WorkArray = (QueryResultRecord & { club: string, association: string, family: string })[];
+
+const REDIS_KEY_POSITION = 'nearby:geo';
+const REDIS_KEY_MEMBER = (m: number | string) => `nearby:${m}`;
+const REDIS_KEY_TTL = 'nearby:ttl';
+
+const REDIS_TEMP_RADIUS = 'nearby:temp_radius';
+const REDIS_TEMP_TTL = 'nearby:temp_ttl';
+const REDIS_RESULT_RADIUS = 'nearby:result_radius';
 
 export class RedisLocationStorage implements ILocationStorage {
     private client!: IORedisClient;
@@ -17,7 +27,7 @@ export class RedisLocationStorage implements ILocationStorage {
     }
 
     public async locationOf(member: number): Promise<Location | undefined> {
-        const result = await this.client.geopos('nearby:geo', [member.toString()]);
+        const result = await this.client.geopos(REDIS_KEY_POSITION, [member.toString()]);
         if (result.length === 1) {
             return result[0];
         }
@@ -44,18 +54,18 @@ export class RedisLocationStorage implements ILocationStorage {
 
             // search by geolocation in radius, store in temp_radius
             multi.georadiusbymemberStoreDistance(
-                'nearby:geo',
+                REDIS_KEY_POSITION,
                 memberToMatch.toString(),
                 radius * 1000,
                 'm',
-                'nearby:temp_radius',
+                REDIS_TEMP_RADIUS,
             );
 
             // intersect search with ttl -> temp_ttl
             multi.zinterstore(
-                'nearby:temp_ttl',
-                'nearby:temp_radius',
-                'nearby:ttl',
+                REDIS_TEMP_TTL,
+                REDIS_TEMP_RADIUS,
+                REDIS_KEY_TTL,
                 0,
                 1,
             );
@@ -63,7 +73,7 @@ export class RedisLocationStorage implements ILocationStorage {
             if (age) {
                 // remove all older than x days
                 multi.zremrangebyscore(
-                    'nearby:temp_ttl',
+                    REDIS_TEMP_TTL,
                     '-inf',
                     Date.now() - age * 1000 * 60 * 60 * 24,
                 );
@@ -71,16 +81,16 @@ export class RedisLocationStorage implements ILocationStorage {
 
             // get radius for not oldest members
             multi.zinterstore(
-                'nearby:result_radius',
-                'nearby:temp_radius',
-                'nearby:temp_ttl',
+                REDIS_RESULT_RADIUS,
+                REDIS_TEMP_RADIUS,
+                REDIS_TEMP_TTL,
                 1,
                 0,
             );
 
             // get nearest 20 elements
             multi.zrange(
-                'nearby:result_radius',
+                REDIS_RESULT_RADIUS,
                 0,
 
                 // we query double the size to be able to exclude those without
@@ -100,7 +110,7 @@ export class RedisLocationStorage implements ILocationStorage {
                 // [1] is score = distance
                 const distance = parseFloat(c[1]);
 
-                memberWithDistance[`nearby:${c[0]}`] = {
+                memberWithDistance[REDIS_KEY_MEMBER(c[0])] = {
                     member,
                     distance,
                 };
@@ -116,43 +126,117 @@ export class RedisLocationStorage implements ILocationStorage {
 
             // We take the location from the mget, not the georadius.
             // Such, there can/will be a drift in the position, but only the distance will be wrong.
-            const result = await this.client.mget(ids);
-
-            // can show on map?
-            const mapEnabled = await this.context.dataSources.location.isMembersVisibleOnMap(
-                values(memberWithDistance).map((i: any) => parseInt(i.member, 10)));
+            const locations = await this.client.mget(ids);
 
             // we sort them by
-            const resultArray: (QueryResultRecord & { club: string, association: string, family: string })[] = [];
+            const allResult: WorkArray = [];
 
             // we must preserve order
-            ids.forEach((k, i) => {
+            ids.forEach((k) => {
                 const md = memberWithDistance[k];
-                const r = result[k];
+                const r = locations[k];
 
-                resultArray.push({
+                if (!r.address) {
+                    // we don't have an address
+                    return;
+                }
+
+                if (md.member === this.context.principal.id) {
+                    // we exclue ourself
+                    return;
+                }
+
+                // tslint:disable-next-line: triple-equals
+                if (excludeOwnTable && r.club == this.context.principal.club) {
+                    // we must exclude our own table
+                    return;
+                }
+
+                allResult.push({
                     ...r,
                     location: r.location || r.position, // compat
                     lastseen: new Date(r.lastseen),
                     accuracy: Math.round(r.accuracy),
                     distance: Math.round(md.distance),
                     member: md.member,
-                    canshowonmap: mapEnabled[i],
+                    // canshowonmap: mapEnabled[i],
                 });
             });
 
-            return take(
-                filter(
-                    resultArray,
-                    (m) => m.member !== memberToMatch
-                        && m.address
-                        && (excludeOwnTable && m.club !== this.context.principal.club || !excludeOwnTable),
-                ),
-                count,
-            ) as QueryResult;
+            let countResults: WorkArray = [];
+            let remaining = allResult;
+            while (remaining.length > 0) {
+                // we fetch only the required amount * 2
+                const nextSequenceAmount = Math.abs(
+                    Math.min(count, (count - countResults.length) * 2),
+                );
+
+                this.context.logger.debug(
+                    'Update results',
+                    'total', allResult.length,
+                    'taken', countResults.length,
+                    'remaining', remaining.length,
+                    'next amount', nextSequenceAmount,
+                );
+
+                const testSequence = take(remaining, nextSequenceAmount);
+                remaining = slice(remaining, nextSequenceAmount);
+
+                countResults.push(... await this.filterSequence(testSequence));
+                if (countResults.length >= count) {
+                    countResults = take(countResults, count);
+                    break;
+                }
+            }
+
+            if (countResults.length === 0) {
+                return [];
+            }
+
+            // add mapEnabled flag for the rest of the records
+            const mapEnabled = await this.context.dataSources.location.isMembersVisibleOnMap(
+                values(countResults).map((i: any) => parseInt(i.member, 10)));
+
+            countResults.forEach((e, i) => {
+                e.canshowonmap = mapEnabled[i];
+            });
+
+            return countResults as QueryResult;
         } finally {
             this.context.metrics.add({ id: Metrics.QueryLocation, value: sw.elapsedYs, unit: 'μs' });
         }
+    }
+
+    async filterSequence(filteredResult: WorkArray) {
+        // most likely they will be loaded anyhow, this doesn't hurt much
+        // in case of missing entries, we cannot prevent the round trip to the database
+        const members = await this.context.dataSources.members.readMany(
+            values(filteredResult).map((i: any) => parseInt(i.member, 10)));
+
+        const finalResult: (QueryResultRecord & { club: string, association: string, family: string })[] = [];
+        const removals: number[] = [];
+        members.forEach((m, i) => {
+            // member is no longer active
+            if (!m) {
+                removals.push(filteredResult[i].member);
+            } else {
+                finalResult.push(filteredResult[i]);
+            }
+        });
+
+        // cleanup stale data
+        if (removals.length > 0) {
+            this.context.logger.log('Cleaning up', removals);
+            const cleanup = await this.client.multi();
+
+            cleanup.hdel(REDIS_KEY_POSITION, removals.map((r) => r.toString()));
+            cleanup.del(...removals.map((r) => REDIS_KEY_MEMBER(r)));
+            cleanup.zrem(REDIS_KEY_TTL, ...removals.map((r) => r.toString()));
+
+            await cleanup.exec();
+        }
+
+        return finalResult;
     }
 
     public async putLocation(
@@ -169,7 +253,7 @@ export class RedisLocationStorage implements ILocationStorage {
 
         // point
         multi.geoadd(
-            'nearby:geo',
+            REDIS_KEY_POSITION,
             longitude,
             latitude,
             member.toString(),
@@ -177,7 +261,7 @@ export class RedisLocationStorage implements ILocationStorage {
 
         // details of last location
         multi.set(
-            `nearby:${member}`,
+            REDIS_KEY_MEMBER(member),
             {
                 speed,
                 address,
@@ -190,7 +274,7 @@ export class RedisLocationStorage implements ILocationStorage {
 
         // newest members first
         multi.zadd(
-            'nearby:ttl',
+            REDIS_KEY_TTL,
             lastseen.valueOf(),
             member.toString(),
         );


### PR DESCRIPTION
Fixed an issue where RedisLocation client might return members that no longer exist in the database. They are never returned, but the query fails until the location times out.